### PR TITLE
Update Satellite_Imagery_DeepLearning-Base.ipynb

### DIFF
--- a/DL-SatelliteImagery/Satellite_Imagery_DeepLearning-Base.ipynb
+++ b/DL-SatelliteImagery/Satellite_Imagery_DeepLearning-Base.ipynb
@@ -905,7 +905,16 @@
     {
       "cell_type": "code",
       "source": [
-        "import segmentation_models as sm"
+        "
+import tensorflow as tf
+
+# Force using TensorFlow Keras
+import os
+os.environ['SM_FRAMEWORK'] = 'tf.keras'
+
+import segmentation_models as sm
+#newer version of Keras (now integrated into TensorFlow)
+"
       ],
       "metadata": {
         "colab": {


### PR DESCRIPTION
segmentation_models is likely using older Keras APIs, including generic_utils, which have been restructured in TensorFlow Keras.

 The SM_FRAMEWORK environment variable forces segmentation_models to use TensorFlow Keras.